### PR TITLE
Add version to OTP xcomp files

### DIFF
--- a/src/rebar3_grisp_build.erl
+++ b/src/rebar3_grisp_build.erl
@@ -58,10 +58,11 @@ do(State) ->
     copy_code(Apps, Board, BuildRoot, Version),
 
     info("Building"),
-    ErlXComp = find_file(Apps, Board, ["xcomp", "erl-xcomp.conf"]),
+    ErlXComp = "erl-xcomp-" ++ Version ++ ".conf",
+    ErlXCompPath = find_file(Apps, Board, ["xcomp", ErlXComp]),
     BuildConfFile = config_file(Apps, Board, ["grisp.conf"]),
     BuildConfig = rebar3_grisp_util:merge_config(Config, BuildConfFile),
-    build(BuildConfig, ErlXComp, BuildRoot, InstallRoot, Opts),
+    build(BuildConfig, ErlXCompPath, BuildRoot, InstallRoot, Opts),
 
     info("Done"),
     {ok, State}.


### PR DESCRIPTION
Now that the xcomp file is not coming from the OTP checkout we need it versioned to still be able to build multiple versions.