### PR TITLE
deploy: added support for whitespaces in source and deployment directories

### DIFF
--- a/src/rebar3_grisp_deploy.erl
+++ b/src/rebar3_grisp_deploy.erl
@@ -208,8 +208,8 @@ load_file(Source, _Context) ->
 
 copy_release(State, Name, _Version, Dest, Force) ->
     console("* Copying release..."),
-    Source = filename:join([rebar_dir:base_dir(State), "rel", Name]),
-    Target = filename:join(Dest, Name),
+    Source = "\"" ++ filename:join([rebar_dir:base_dir(State), "rel", Name]) ++ "\"",
+    Target = "\"" ++ filename:join(Dest, Name) ++ "\"",
     Command = case Force of
         true  -> "cp -Rf";
         false -> "cp -R"


### PR DESCRIPTION
Adds " to the deployment target and source directory before passing it to the shell