### PR TITLE
Include environment variables in templates

### DIFF
--- a/src/rebar3_grisp_build.erl
+++ b/src/rebar3_grisp_build.erl
@@ -204,14 +204,13 @@ patch_otp(OTPRoot, Drivers, Version) ->
 
 apply_patch(TemplateFile, Drivers, OTPRoot) ->
     debug("Using Template ~p", [TemplateFile]),
-    Template = bbmustache:parse_file(TemplateFile),
     Context = [
         {erts_emulator_makefile_in, [
             {lines, 10 + length(Drivers)},
             {drivers, [[{name, filename:basename(N, ".c")}] || N <- Drivers]}
         ]}
     ],
-    Patch = bbmustache:compile(Template, Context, [{key_type, atom}]),
+    Patch = rebar3_grisp_template:render(TemplateFile, Context),
     ok = file:write_file(filename:join(OTPRoot, "otp.patch"), Patch),
     case sh("git apply otp.patch --reverse --check", [{cd, OTPRoot}, return_on_error]) of
         {ok, _} ->

--- a/src/rebar3_grisp_deploy.erl
+++ b/src/rebar3_grisp_deploy.erl
@@ -182,10 +182,10 @@ resolve_files([File|Files], Root, Resolved) ->
     Relative = prefix(File, Root ++ "/"),
     Name = filename:rootname(Relative, ".mustache"),
     resolve_files(Files, Root, maps:put(
-                                 Name,
-                                 resolve_file(Root, Relative, Name, maps:find(Name, Resolved)),
-                                 Resolved
-                                ));
+        Name,
+        resolve_file(Root, Relative, Name, maps:find(Name, Resolved)),
+        Resolved
+    ));
 resolve_files([], _Root, Resolved) ->
     Resolved.
 
@@ -201,8 +201,7 @@ resolve_file(Root, Source, _Target, _) ->
     {template, filename:join(Root, Source)}.
 
 load_file({template, Source}, Context) ->
-    Parsed = bbmustache:parse_file(Source),
-    bbmustache:compile(Parsed, Context, [{key_type, atom}]);
+    rebar3_grisp_template:render(Source, Context);
 load_file(Source, _Context) ->
     {ok, Binary} = file:read_file(Source),
     Binary.

--- a/src/rebar3_grisp_template.erl
+++ b/src/rebar3_grisp_template.erl
@@ -1,0 +1,25 @@
+-module(rebar3_grisp_template).
+
+% API
+-export([render/2]).
+
+%--- API -----------------------------------------------------------------------
+
+render(File, Context) ->
+    Parsed = bbmustache:parse_file(File),
+    bbmustache:compile(Parsed, default(Context), [
+        {key_type, atom},
+        raise_on_context_miss
+    ]).
+
+%--- Internal ------------------------------------------------------------------
+
+default(Context) -> maps:merge(env(), Context).
+
+env() -> #{env => maps:from_list([parse_env(E) || E <- os:getenv()])}.
+
+parse_env(E) ->
+    {match, [Name, Value]} = re:run(E, "([^=]+)=(.*)", [
+        {capture, all_but_first, binary}
+    ]),
+    {binary_to_atom(Name, utf8), Value}.


### PR DESCRIPTION
Makes it possible to use environment variables in templates under the key `env`. For example in `grisp.ini.mustache`:

```
[erlang]
args = erl.rtems -- … -setcookie {{env.MY_ERLANG_COOKIE}}
```