### PR TITLE
Revert "Prebuild OTP filename depends on Board now"

### DIFF
--- a/src/rebar3_grisp_build.erl
+++ b/src/rebar3_grisp_build.erl
@@ -91,7 +91,7 @@ do(State) ->
 
     case rebar3_grisp_util:get(tar, Opts, false) of
         true ->
-            Filename = tar_file_name(GrispFolder, Board, Version, Hash),
+            Filename = tar_file_name(GrispFolder, Version, Hash),
             info("Creating package ~p", [Filename]),
             create_tar(Filename, InstallRoot);
         false -> ok
@@ -123,9 +123,9 @@ copy_files(Apps, Board, BuildRoot) ->
      ),
     {DriverFiles, NIFFiles}.
 
-tar_file_name(GrispFolder, Board, Version, Hash) ->
+tar_file_name(GrispFolder, Version, Hash) ->
     filename:join([GrispFolder, "otp", Version, "package",
-                   rebar3_grisp_util:otp_cache_file_name(Board, Version, Hash)]).
+                   rebar3_grisp_util:otp_cache_file_name(Version, Hash)]).
 
 create_tar(Filename, InstallRoot) ->
     rebar3_grisp_util:ensure_dir(Filename),

--- a/src/rebar3_grisp_util.erl
+++ b/src/rebar3_grisp_util.erl
@@ -23,7 +23,7 @@
 -export([otp_git/0]).
 -export([board/1]).
 -export([otp_build_root/2]).
--export([otp_cache_file_name/3]).
+-export([otp_cache_file_name/2]).
 -export([otp_build_install_root/2]).
 -export([otp_hash_listing_path/1]).
 -export([merge_config/2]).
@@ -103,8 +103,8 @@ otp_build_root(RebarState, Version) ->
 otp_build_install_root(RebarState, Version) ->
     filename:join([root(RebarState), "otp", Version, "install"]).
 
-otp_cache_file_name(Board, Version, Hash) when is_list(Board), is_list(Version), is_list(Hash) ->
-    Board ++ "_otp_build_" ++ Version ++ "_" ++ Hash ++ ".tar.gz".
+otp_cache_file_name(Version, Hash) when is_list(Version), is_list(Hash) ->
+    "grisp_otp_build_" ++ Version ++ "_" ++ Hash ++ ".tar.gz".
 
 otp_hash_listing_path(InstallRoot) ->
     filename:join([InstallRoot, "GRISP_PACKAGE_FILES"]).


### PR DESCRIPTION
This reverts commit 5288128145524974885fd36e9651c0b8dce9c595.