### PR TITLE
Remove deprecated maintainers section

### DIFF
--- a/src/rebar3_grisp.app.src
+++ b/src/rebar3_grisp.app.src
@@ -10,10 +10,6 @@
     {env, []},
     {modules, []},
 
-    {maintainers, [
-        "Peer Stritzinger",
-        "Adam Lindberg"
-    ]},
     {licenses, ["Apache 2.0"]},
     {links, [
         {"GitHub",


### PR DESCRIPTION
Prevents me from publishing to hex.pm.
See https://github.com/hexpm/hex/blob/master/CHANGELOG.md#ignoring-maintainers-field