### PR TITLE
CI update OTP 24 and 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,14 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:
         otp:
+          - '26'
+          - '25'
           - '24'
-          - '23'
         rebar3:
           - '3'
     steps:


### PR DESCRIPTION
This PR updates the CI by removing the task on OTP 23 and adding a task for OTP 24 and 25

The changes are the same as this [commit](https://github.com/grisp/rebar3_grisp/pull/76/commits/271d43b45d0f6cefb1263edd7494f33838e19f44) from https://github.com/grisp/rebar3_grisp/pull/76