### PR TITLE
SEA-232 fix http escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ rebar3 grisp configure -i false --name="my_grisp_app" -n true -w true --ssid="my
 ```
 This command will create a new GRiSP project named "my_grisp_app" with a network (`-n true`) and wifi (`-w true`) configuration already setup. The configuration will use the ssid "mywifi" and the psk "wifipsk".
 
+
+
 Note that some options require others. For example, if you want to setup the ssid of the wifi, then you also need to activate the network and wifi configuration (`-n true` and `-w true`).
 
 The specific variables provided by this plug-in are:
@@ -99,7 +101,7 @@ Some variables are modfiable only through the command line. These variables are:
 * **`author_name`** is the name of the author of the project
 * **`author_email`** is the email of the author of the project 
 
-For a full list of customizable variables, run `rebar3 help grisp configure`.
+For a full list of customizable variables as well as their short form, run `rebar3 help grisp configure`.
 
 In the interactive mode you can also specify a few variables. During the CLI interaction, the questions related to these variable will be skipped. For example:
 

--- a/priv/templates/common/LICENSE
+++ b/priv/templates/common/LICENSE
@@ -175,7 +175,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-Copyright {{copyright_year}}, {{author_name}} <{{author_email}}>.
+Copyright {{{copyright_year}}}, {{{author_name}}} <{{{author_email}}}>.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/priv/templates/common/README.md
+++ b/priv/templates/common/README.md
@@ -1,7 +1,7 @@
-{{name}}
+{{{name}}}
 =====
 
-{{desc}}
+{{{desc}}}
 
 Build
 -----

--- a/priv/templates/common/app.erl
+++ b/priv/templates/common/app.erl
@@ -1,5 +1,5 @@
-% @doc {{name}} public API.
--module({{name}}).
+% @doc {{{name}}} public API.
+-module({{{name}}}).
 
 -behavior(application).
 
@@ -10,7 +10,7 @@
 %--- Callbacks -----------------------------------------------------------------
 
 % @private
-start(_Type, _Args) -> {{name}}_sup:start_link().
+start(_Type, _Args) -> {{{name}}}_sup:start_link().
 
 % @private
 stop(_State) -> ok.

--- a/priv/templates/common/otp_app.app.src
+++ b/priv/templates/common/otp_app.app.src
@@ -1,8 +1,8 @@
-{application, {{name}}, [
-    {description, "{{desc}}"},
+{application, {{{name}}}, [
+    {description, "{{{desc}}}"},
     {vsn, "0.1.0"},
     {registered, []},
-    {mod, {{{name}}, []}},
+    {mod, {{{{name}}}, []}},
     {applications, [
         kernel,
         stdlib,

--- a/priv/templates/common/rebar.config
+++ b/priv/templates/common/rebar.config
@@ -11,20 +11,20 @@
 
 {grisp, [
     {otp, [
-        {version, "{{otp_version}}"}
+        {version, "{{{otp_version}}}"}
     ]},
     {deploy, [
-        {destination, "{{dest}}"}
+        {destination, "{{{dest}}}"}
     ]}
 ]}.
 
 {shell, [{apps, []}]}.
 
 {relx, [
-    {release, {{{name}}, "0.1.0"}, [
+    {release, {{{{name}}}, "0.1.0"}, [
         {{#epmd}}
         {epmd, none},
         {{/epmd}}
-        {{name}}
+        {{{name}}}
     ]}
 ]}.

--- a/priv/templates/common/sup.erl
+++ b/priv/templates/common/sup.erl
@@ -1,6 +1,6 @@
 % @private
-% @doc {{name}} top level supervisor.
--module({{name}}_sup).
+% @doc {{{name}}} top level supervisor.
+-module({{{name}}}_sup).
 
 -behavior(supervisor).
 

--- a/priv/templates/common/sys.config
+++ b/priv/templates/common/sys.config
@@ -1,7 +1,7 @@
 [
 {{#grisp_io_linking}}    {grisp_connect,[
-        {device_linking_token,<<"{{token}}">>}
+        {device_linking_token,<<"{{{token}}}">>}
     ]},
-{{/grisp_io_linking}}    {{{name}}, [
+{{/grisp_io_linking}}    {{{{name}}}, [
     ]}
 ].

--- a/priv/templates/network/grisp.ini.mustache
+++ b/priv/templates/network/grisp.ini.mustache
@@ -1,6 +1,6 @@
 {{=<% %>=}}
 [erlang]
-args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -bindir {{release_name}}/erts-{{erts_vsn}}/bin -boot {{release_name}}/releases/{{release_version}}/start -config {{release_name}}/releases/{{release_version}}/sys.config <%#network%>-kernel inetrc "./erl_inetrc"<%/network%> <%#epmd%>-internal_epmd epmd_sup -sname {{release_name}} -setcookie <%cookie%><%/epmd%>
+args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -bindir {{release_name}}/erts-{{erts_vsn}}/bin -boot {{release_name}}/releases/{{release_version}}/start -config {{release_name}}/releases/{{release_version}}/sys.config <%#network%>-kernel inetrc "./erl_inetrc"<%/network%> <%#epmd%>-internal_epmd epmd_sup -sname {{release_name}} -setcookie <%={{ }}=%> {{{cookie}}} {{=<% %>=}} <%/epmd%>
 shell = erlang
 
 [network]

--- a/priv/templates/network/wpa_supplicant.conf
+++ b/priv/templates/network/wpa_supplicant.conf
@@ -1,5 +1,5 @@
 network={
-    ssid="{{ssid}}"
+    ssid="{{{ssid}}}"
     key_mgmt=WPA-PSK
-    psk="{{psk}}"
+    psk="{{{psk}}}"
 }

--- a/src/rebar3_grisp_configure.erl
+++ b/src/rebar3_grisp_configure.erl
@@ -122,10 +122,10 @@ do(RState) ->
           end, Files),
 
         case ProjectExists of
-            true -> warn("Warning: The project directory already exists,"
-                         ++ "and existing files were not overwritten."
-                         ++ "Please review the files to ensure all"
-                         ++ "configurations are correct");
+            true -> warn("Warning: The project directory already exists, "
+                         ++ "and existing files were not overwritten. "
+                         ++ "Please review the files to ensure all "
+                         ++ "configurations are correct. ");
             _ -> ok
         end,
 

--- a/src/rebar3_grisp_configure.erl
+++ b/src/rebar3_grisp_configure.erl
@@ -105,14 +105,27 @@ do(RState) ->
         {ok, Cwd} = file:get_cwd(),
         PrivDir = code:priv_dir(rebar3_grisp),
         TemplatesDir = filename:join(PrivDir, "templates"),
+        FormatedFlags = maps:map(
+                          fun(_Key, Value) ->
+                             case is_list(Value) of
+                                 true ->
+                                     unicode:characters_to_binary(Value);
+                                 false ->
+                                     Value
+                             end
+                          end, Flags),
         lists:map(fun({From, To}) ->
                       FilePath = filename:join(TemplatesDir, From),
-                      maybe_write_file(FilePath, filename:join(Cwd, To), Flags)
+                      maybe_write_file(FilePath,
+                                       filename:join(Cwd, To),
+                                       FormatedFlags)
           end, Files),
 
         case ProjectExists of
-            true -> warn("Warning: The project directory already exists, and existing files were not overwritten.
-                         Please review the files to ensure all configurations are correct");
+            true -> warn("Warning: The project directory already exists,"
+                         ++ "and existing files were not overwritten."
+                         ++ "Please review the files to ensure all"
+                         ++ "configurations are correct");
             _ -> ok
         end,
 


### PR DESCRIPTION
In this PR, the templates have been modified to avoid http escaping. For examples, quotes (") are now rendered as `"` and not `&quote;`
This PR is linked to the PR on `grisp_tools`: https://github.com/grisp/grisp_tools/pull/23