### PR TITLE
Fix package command behaviour

### DIFF
--- a/src/rebar3_grisp_package.erl
+++ b/src/rebar3_grisp_package.erl
@@ -77,13 +77,6 @@ task_help("list", _Args, RState) ->
         "  -x, --hash      List package hashes [default: false]~n"
     ),
     RState;
-task_help("download", _Args, RState) ->
-    console(
-        "Download packages~n"
-        "~n"
-        "Foo"
-    ),
-    RState;
 task_help(undefined, _Args, RState) ->
     Args = [atom_to_list(A) || A <- [?NAMESPACE, ?TASK]],
     {ok, RState2} = rebar_prv_help:do(rebar_state:command_args(RState, Args)),
@@ -115,11 +108,8 @@ task_run("list", {Args, _Rest}, RState) ->
             abort("Listing of ~p ~p packages not supported", [Source, Type])
     end,
     RState;
-task_run("download", {Args, _Rest}, RState) ->
-    console("~p", [Args]),
-    RState;
-task_run(Task, _Args, _State) ->
-    abort("~p: unknown task: ~s", [?TASK, Task]).
+task_run(Task, _Args, RState) ->
+    task_help(undefined, _Args, RState).
 
 parse_columns(otp, undefined) ->
     [version];

--- a/src/rebar3_grisp_package.erl
+++ b/src/rebar3_grisp_package.erl
@@ -108,7 +108,7 @@ task_run("list", {Args, _Rest}, RState) ->
             abort("Listing of ~p ~p packages not supported", [Source, Type])
     end,
     RState;
-task_run(Task, _Args, RState) ->
+task_run(_Task, _Args, RState) ->
     task_help(undefined, _Args, RState).
 
 parse_columns(otp, undefined) ->


### PR DESCRIPTION
Print the help text if no subtask is provided

```
% rebar3 grisp package     
===> Analyzing applications...
===> Compiling grisp_tools
===> Compiling textual
===> Compiling grid
===> Compiling rebar3_grisp
===> Analyzing applications...
===> Compiling grisp_tools
===> Compiling textual
===> Compiling grid
===> Compiling rebar3_grisp
Pre-built packages tasks

Commands:
  list          List packages

Usage: rebar3 grisp package [-p [<platform>]] [-c <columns>] [-t [<type>]]
                            [-c [<cached>]]

  -p, --platform  Platform to list packages for [default: grisp2]
  -c, --columns   List columns to display
  -t, --type      Package type [default: otp]
  -c, --cached    List only cached packages [default: false]

```

Fixes https://github.com/grisp/rebar3_grisp/issues/77