### PR TITLE
update templates of `rebar3 grisp configure` for grisp.io

### DIFF
--- a/priv/templates/common/rebar.config
+++ b/priv/templates/common/rebar.config
@@ -28,6 +28,7 @@
         {{/epmd}}
         {{#grisp_io}}
         {grisp_updater_grisp2, load},
+        sasl
         {{/grisp_io}}
         {{{name}}}
     ]}

--- a/priv/templates/common/rebar.config
+++ b/priv/templates/common/rebar.config
@@ -28,7 +28,7 @@
         {{/epmd}}
         {{#grisp_io}}
         {grisp_updater_grisp2, load},
-        sasl
+        sasl,
         {{/grisp_io}}
         {{{name}}}
     ]}

--- a/priv/templates/common/rebar.config
+++ b/priv/templates/common/rebar.config
@@ -1,5 +1,6 @@
 {deps, [
-    {{^grisp_io}}grisp{{/grisp_io}}{{#grisp_io}}{grisp_connect, {git, "https://github.com/grisp/grisp_connect", {branch, "main"}}}{{/grisp_io}}{{^epmd}}
+    {{^grisp_io}}grisp{{/grisp_io}}{{#grisp_io}}{grisp_connect, "1.0.0"},
+    grisp_updater_grisp2{{/grisp_io}}{{^epmd}}
 {{/epmd}}{{#epmd}},
     {epmd, {git, "https://github.com/erlang/epmd", {ref, "4d1a59"}}}
     {{/epmd}}
@@ -25,6 +26,9 @@
         {{#epmd}}
         {epmd, none},
         {{/epmd}}
+        {{#grisp_io}}
+        {grisp_updater_grisp2, load},
+        {{/grisp_io}}
         {{{name}}}
     ]}
 ]}.

--- a/priv/templates/common/sys.config
+++ b/priv/templates/common/sys.config
@@ -2,6 +2,16 @@
 {{#grisp_io_linking}}    {grisp_connect,[
         {device_linking_token,<<"{{{token}}}">>}
     ]},
-{{/grisp_io_linking}}    {{{{name}}}, [
+{{/grisp_io_linking}}
+{{#grisp_io}}    {grisp_updater, [
+        {system, {grisp_updater_grisp2, #{}}},
+        {sources, [
+            {grisp_updater_tarball, #{}},
+            {grisp_updater_http, #{
+                backend => {grisp_updater_grisp2, #{}}
+            }}
+        ]}
+    ]},
+{{/grisp_io}}    {{{{name}}}, [
     ]}
 ].

--- a/priv/templates/common/sys.config
+++ b/priv/templates/common/sys.config
@@ -4,6 +4,8 @@
     ]},
 {{/grisp_io_linking}}
 {{#grisp_io}}    {grisp_updater, [
+        {signature_check, false}, % Set to 'true' and uncomment next line to enable signature check
+        % {signature_certificates, {priv, grisp_demo, "certificates/updates"}},
         {system, {grisp_updater_grisp2, #{}}},
         {sources, [
             {grisp_updater_tarball, #{}},

--- a/priv/templates/network/grisp.ini.mustache
+++ b/priv/templates/network/grisp.ini.mustache
@@ -2,6 +2,8 @@
 [erlang]
 args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -bindir {{release_name}}/erts-{{erts_vsn}}/bin -boot {{release_name}}/releases/{{release_version}}/start -config {{release_name}}/releases/{{release_version}}/sys.config <%#network%>-kernel inetrc "./erl_inetrc"<%/network%> <%#epmd%>-internal_epmd epmd_sup -sname {{release_name}} -setcookie <%={{ }}=%> {{{cookie}}} {{=<% %>=}} <%/epmd%>
 shell = erlang
+on_exit = reboot
+on_crash = reboot
 
 [network]
 ip_self=dhcp


### PR DESCRIPTION
The current version of the templates used by `rebar3 grisp configure` were not up to date with the latest changes of grisp.io.

- With the first release of `grisp_connect` the template can now tag v1.0.0 instead of the main branch
- `grisp_updater_grisp2` wasn't included in the deps if the user decided to create a grisp.io app. It it now the case

## How to test ?
1. Create a dummy rebar3  project
2. Include `rebar3_grisp` in the plugin section of the `rebar.config` file of that project
3. Create the `_checkouts` directory in that dummy project
4. Either clone or create a simlink to this repository
    4.1. Checkout this branch
5. You can now run `rebar3 grisp configure` inside your dummy project and generate GRiSP apps