### PR TITLE
remove test profile from generated files

### DIFF
--- a/src/rebar3_grisp_util.erl
+++ b/src/rebar3_grisp_util.erl
@@ -311,7 +311,7 @@ index_releases(Releases) ->
 
 profile_postfix(RebarState) ->
     AllProfiles = rebar_state:current_profiles(RebarState),
-    case [atom_to_binary(P) || P <- AllProfiles, P =/= default, P =/= grisp] of
+    case [atom_to_binary(P) || P <- AllProfiles, P =/= default, P =/= grisp, P =/= test] of
         [] -> <<"">>;
         Profiles -> iolist_to_binary([".", lists:join($+, Profiles)])
     end.


### PR DESCRIPTION
Remove the test profile from the generated files when using `pack`