### PR TITLE
Add manifest validation events handling

### DIFF
--- a/src/rebar3_grisp_firmware.erl
+++ b/src/rebar3_grisp_firmware.erl
@@ -293,7 +293,7 @@ event([firmware, prepare, _, {error, not_a_file, Path}]) ->
 event([firmware, build_firmware, create_image]) ->
     console("* Creating disk image...");
 event([firmware, build_firmware, create_image, {error, Reason}]) ->
-    abort_message("Failed to create firmware image file: ~s", Reason);
+    abort_message("Failed to create firmware image file", Reason);
 event([firmware, build_firmware, copy_bootloader]) ->
     console("* Writing bootloader...");
 event([firmware, build_firmware, copy_bootloader, {error, Reason}]) ->


### PR DESCRIPTION
These are some changed that are required to properly show the status of manifest validation during the pack command. This is needed by a PR already merged in grisp_tools but I forgot to push the changes in rebar3_grisp. As this is a bit old, it would be best if you validate that this is still working for you with the last main of grisp_tools, that the pack command is working as expected and showing the proper messages when run.