### PR TITLE
Update CI Workflow and Dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         rebar3: ['3']
         # latest rebar3 versions that do not give problems with selected OTPs
         include:
-          - otp: '23'
+          - otp: '23.3.4.18'
             rebar3: '3.20.0'
           - otp: '24'
             rebar3: '3.23.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         rebar3: ['3']
         # latest rebar3 versions that do not give problems with selected OTPs
         include:
-          - otp: '23.3.4.18'
-            rebar3: '3.20.0'
           - otp: '24'
             rebar3: '3.23.0'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
             rebar3: '3.23.0'
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         env:
           cache-name: rebar3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,19 +1,18 @@
-%% rebar.config.script for plugin
+%% rebar.config.script
 
-%% Detect OTP version
+%% OTP version
 OTPVersionStr = erlang:system_info(otp_release),
 OTPVersion = list_to_integer(OTPVersionStr).
 
-%% Decide erlexec version
-ErlexecVersion = if
-    OTPVersion < 27 -> "2.0.7";
-    true -> "latest"
+if
+    OTPVersion < 27 -> 
+        [{overrides, [
+            {override, edifa, [
+                {deps, [
+                    {erlexec, "2.0.7"}
+                ]}
+            ]}
+        ]}];
+    true -> 
+        []
 end.
-
-[{overrides, [
-    {override, edifa, [
-        {deps, [
-            {erlexec, ErlexecVersion}
-        ]}
-    ]}
-]}].

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,19 @@
+%% rebar.config.script for plugin
+
+%% Detect OTP version
+OTPVersionStr = erlang:system_info(otp_release),
+OTPVersion = list_to_integer(OTPVersionStr).
+
+%% Decide erlexec version
+ErlexecVersion = if
+    OTPVersion < 27 -> "2.0.7";
+    true -> "latest"
+end.
+
+[{overrides, [
+    {override, edifa, [
+        {deps, [
+            {erlexec, ErlexecVersion}
+        ]}
+    ]}
+]}].


### PR DESCRIPTION
This PR updates the CI workflow by upgrading GitHub Actions to their latest stable versions (checkout@v4 and cache@v4) and removes support for OTP 23 which is no longer listed on `erlef/setup-beam@v1`.
Additionally, it adds rebar3 script configuration to ensure `erlexec 2.0.7` for OTP versions below 27 