### PR TITLE
unlock the version of grisp_connect in `configure` template

### DIFF
--- a/priv/templates/common/rebar.config
+++ b/priv/templates/common/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-    {{^grisp_io}}grisp{{/grisp_io}}{{#grisp_io}}{grisp_connect, "1.0.0"},
+    {{^grisp_io}}grisp{{/grisp_io}}{{#grisp_io}}grisp_connect,
     grisp_updater_grisp2{{/grisp_io}}{{^epmd}}
 {{/epmd}}{{#epmd}},
     {epmd, {git, "https://github.com/erlang/epmd", {ref, "4d1a59"}}}


### PR DESCRIPTION
This PR unlocks the version of `grisp_connect` in the template. With that, when the user generate a new app using `rebar3 grisp configure`, they will always have the latest version