### PR TITLE
Add new jit config key for the grisp build task

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ rebar3 help grisp [<task>]
   - [Generate GRiSP 2 Firmwares](#generate-grisp-2-firmwares)
     - [Firmware Update](#firmware-update)
     - [Cautions](#cautions)
+      - [With truncated image firmwares](#with-truncated-image-firmwares)
+      - [With writing system firmware on inactive system partition](#with-writing-system-firmware-on-inactive-system-partition)
   - [Build a Software Update Package](#build-a-software-update-package)
     - [Updating a GRiSP Board](#updating-a-grisp-board)
   - [Listing Packages](#listing-packages)
@@ -489,6 +491,7 @@ Add the path to the toolchain to the `rebar.config` under `grisp` â†’ `build` â†
 ```erlang
 {grisp, [
     {otp, [{version, "25"}]},
+    {jit, true}, % applies jit patches if available, enabling the jit
     {build, [
         {toolchain, [
             {directory, "/PATH/TO/grisp2-rtems-toolchain/rtems/VERSION/"}

--- a/src/rebar3_grisp_build.erl
+++ b/src/rebar3_grisp_build.erl
@@ -55,6 +55,7 @@ do(RState) ->
 
     Board = rebar3_grisp_util:platform(Config),
     Version = rebar3_grisp_util:otp_version(Config),
+    Jit = rebar3_grisp_util:otp_jit(Config),
 
     Apps = rebar3_grisp_util:apps(RState),
 
@@ -76,6 +77,7 @@ do(RState) ->
             project_root => ProjectRoot,
             apps => Apps,
             otp_version_requirement => Version,
+            jit => Jit,
             platform => Board,
             custom_build => CustomBuild,
             build => #{

--- a/src/rebar3_grisp_util.erl
+++ b/src/rebar3_grisp_util.erl
@@ -22,6 +22,7 @@
 -export([root/1]).
 -export([config/1]).
 -export([otp_version/1]).
+-export([otp_jit/1]).
 -export([platform/1]).
 -export([otp_build_root/2]).
 -export([otp_cache_file_name/2]).
@@ -107,6 +108,9 @@ config(State) ->
 
 otp_version(Config) ->
     get([otp, version], Config, ?DEFAULT_OTP_VSN).
+
+otp_jit(Config) ->
+    get([otp, jit], Config, false).
 
 platform(Config) ->
     try


### PR DESCRIPTION
Adds a new options to apply jit specific patches, see also https://github.com/grisp/grisp_tools/pull/48